### PR TITLE
feat: RSSスクレイピング機能の実装

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "nba-trade-scraper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# 非同期ランタイム
+tokio = { version = "1.40", features = ["full"] }
+
+# HTTPクライアント
+reqwest = { version = "0.12", features = ["json", "cookies"] }
+
+# RSSパーサー
+rss = "2.0"
+
+# 日時処理
+chrono = { version = "0.4", features = ["serde"] }
+
+# シリアライゼーション
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# エラーハンドリング
+anyhow = "1.0"
+thiserror = "1.0"
+
+# ログ出力
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# HTMLパーサー（将来的に使用）
+scraper = "0.20"
+
+# 環境変数
+dotenv = "0.15"
+
+# HTTPサーバー（GraphQL用に後で使用）
+axum = "0.7"
+
+# GraphQL（後で使用）
+async-graphql = { version = "7.0", features = ["apollo_tracing", "log"] }
+async-graphql-axum = "7.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,0 +1,61 @@
+mod scraper;
+
+use anyhow::Result;
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+use crate::scraper::RssParser;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // ログの初期化
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    info!("Starting NBA Trade Scraper...");
+
+    // RSSフィードの取得テスト
+    let parser = RssParser::new();
+    let news = parser.fetch_all_feeds().await?;
+
+    info!("Found {} trade-related news items", news.len());
+
+    // 全件を表示（トレード関連度で分類）
+    println!("\n📊 トレード関連ニュース分析\n");
+    
+    // 明確なトレード情報
+    let trades: Vec<_> = news.iter()
+        .filter(|n| n.title.to_lowercase().contains("trade") || 
+                   n.title.to_lowercase().contains("acquire") ||
+                   n.title.to_lowercase().contains("deal"))
+        .collect();
+    
+    // 契約・サイン関連
+    let signings: Vec<_> = news.iter()
+        .filter(|n| n.title.to_lowercase().contains("sign") || 
+                   n.title.to_lowercase().contains("agree") ||
+                   n.title.to_lowercase().contains("buyout"))
+        .collect();
+    
+    println!("🔄 トレード情報 ({} 件):", trades.len());
+    for (i, item) in trades.iter().take(10).enumerate() {
+        println!("\n  {}. {}", i + 1, item.title);
+        println!("     📅 {}", item.published_at.format("%Y-%m-%d %H:%M"));
+        println!("     📰 {}", item.source);
+    }
+    
+    println!("\n✍️ 契約・サイン情報 ({} 件):", signings.len());
+    for (i, item) in signings.iter().take(10).enumerate() {
+        println!("\n  {}. {}", i + 1, item.title);
+        println!("     📅 {}", item.published_at.format("%Y-%m-%d %H:%M"));
+        println!("     📰 {}", item.source);
+    }
+    
+    println!("\n📈 ソース別統計:");
+    println!("  - ESPN: {} 件", news.iter().filter(|n| matches!(n.source, crate::scraper::NewsSource::ESPN)).count());
+    println!("  - RealGM: {} 件", news.iter().filter(|n| matches!(n.source, crate::scraper::NewsSource::RealGM)).count());
+
+    Ok(())
+}

--- a/backend/src/scraper/mod.rs
+++ b/backend/src/scraper/mod.rs
@@ -1,0 +1,5 @@
+pub mod models;
+pub mod rss_parser;
+
+pub use models::*;
+pub use rss_parser::*;

--- a/backend/src/scraper/models.rs
+++ b/backend/src/scraper/models.rs
@@ -1,0 +1,52 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeNews {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub link: String,
+    pub published_at: DateTime<Utc>,
+    pub source: NewsSource,
+    pub is_trade: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum NewsSource {
+    ESPN,
+    RealGM,
+    HoopsHype,
+    Other(String),
+}
+
+impl std::fmt::Display for NewsSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NewsSource::ESPN => write!(f, "ESPN"),
+            NewsSource::RealGM => write!(f, "RealGM"),
+            NewsSource::HoopsHype => write!(f, "HoopsHype"),
+            NewsSource::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RssFeed {
+    pub url: String,
+    pub source: NewsSource,
+}
+
+impl RssFeed {
+    pub fn new(url: &str, source: NewsSource) -> Self {
+        Self {
+            url: url.to_string(),
+            source,
+        }
+    }
+}
+
+pub const RSS_FEEDS: &[(&str, NewsSource)] = &[
+    ("https://www.espn.com/espn/rss/nba/news", NewsSource::ESPN),
+    ("https://basketball.realgm.com/rss/wiretap/0/0.xml", NewsSource::RealGM),
+];

--- a/backend/src/scraper/rss_parser.rs
+++ b/backend/src/scraper/rss_parser.rs
@@ -1,0 +1,135 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use rss::Channel;
+use tracing::{debug, error, info};
+
+use crate::scraper::models::{NewsSource, RssFeed, TradeNews, RSS_FEEDS};
+
+pub struct RssParser {
+    client: Client,
+}
+
+impl RssParser {
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("Failed to create HTTP client"),
+        }
+    }
+
+    pub async fn fetch_all_feeds(&self) -> Result<Vec<TradeNews>> {
+        let mut all_news = Vec::new();
+
+        for (url, source) in RSS_FEEDS {
+            match self.fetch_feed(&RssFeed::new(url, source.clone())).await {
+                Ok(mut news) => {
+                    info!("Fetched {} items from {}", news.len(), source);
+                    all_news.append(&mut news);
+                }
+                Err(e) => {
+                    error!("Failed to fetch feed from {}: {}", source, e);
+                }
+            }
+        }
+
+        all_news.sort_by(|a, b| b.published_at.cmp(&a.published_at));
+        Ok(all_news)
+    }
+
+    pub async fn fetch_feed(&self, feed: &RssFeed) -> Result<Vec<TradeNews>> {
+        info!("Fetching RSS feed from: {}", feed.url);
+
+        let response = self
+            .client
+            .get(&feed.url)
+            .send()
+            .await
+            .context("Failed to fetch RSS feed")?;
+
+        let content = response
+            .text()
+            .await
+            .context("Failed to read response body")?;
+
+        let channel = Channel::read_from(content.as_bytes())
+            .context("Failed to parse RSS feed")?;
+
+        let mut news_items = Vec::new();
+
+        for item in channel.items() {
+            if let Some(news) = self.parse_rss_item(item, &feed.source) {
+                if self.is_trade_related(&news) {
+                    debug!("Found trade-related news: {}", news.title);
+                    news_items.push(news);
+                }
+            }
+        }
+
+        Ok(news_items)
+    }
+
+    fn parse_rss_item(&self, item: &rss::Item, source: &NewsSource) -> Option<TradeNews> {
+        let title = item.title()?.to_string();
+        let link = item.link()?.to_string();
+        let description = item.description().unwrap_or("").to_string();
+
+        let published_at = item
+            .pub_date()
+            .and_then(|date| DateTime::parse_from_rfc2822(date).ok())
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(Utc::now);
+
+        let id = item
+            .guid()
+            .map(|g| g.value().to_string())
+            .unwrap_or_else(|| {
+                format!("{}-{}", source, published_at.timestamp())
+            });
+
+        Some(TradeNews {
+            id,
+            title,
+            description,
+            link,
+            published_at,
+            source: source.clone(),
+            is_trade: false, // Will be determined by is_trade_related
+        })
+    }
+
+    fn is_trade_related(&self, news: &TradeNews) -> bool {
+        let keywords = vec![
+            "trade", "traded", "acquire", "acquired", "deal", "sign",
+            "waive", "waived", "buyout", "release", "released",
+            "exchange", "send", "sent", "receive", "swap",
+        ];
+
+        let text = format!("{} {}", news.title.to_lowercase(), news.description.to_lowercase());
+        
+        keywords.iter().any(|keyword| text.contains(keyword))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_fetch_feeds() {
+        let parser = RssParser::new();
+        let result = parser.fetch_all_feeds().await;
+        
+        assert!(result.is_ok());
+        let news = result.unwrap();
+        
+        if !news.is_empty() {
+            println!("Found {} trade-related news items", news.len());
+            for item in news.iter().take(5) {
+                println!("- {} ({})", item.title, item.source);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
NBA トレード情報を収集するRSSスクレイピング機能を実装しました。

## 実装内容
### スクレイピング機能
- ESPN NBA News RSS フィード対応
- RealGM Wiretap RSS フィード対応
- トレード関連キーワードによるフィルタリング
  - trade, acquire, deal, sign, buyout など

### データモデル
- `TradeNews`: トレードニュース構造体
- `NewsSource`: ニュースソースの列挙型
- 日時順ソート機能

### 技術的な実装
- 非同期処理（tokio/reqwest）
- RSSパーサー（rss crate）
- エラーハンドリング（anyhow）
- ログ出力（tracing）

## 動作確認
```bash
cd backend
cargo run
```

実行結果：
- ESPN: 3件
- RealGM: 22件
- 合計25件のトレード関連ニュースを取得

## Test plan
- [x] cargo build が成功する
- [x] cargo run でRSSフィードを取得できる
- [x] トレード関連ニュースのフィルタリングが機能する
- [x] 日時順ソートが正しく動作する

## 次のステップ
- GraphQLサーバーの実装
- 取得データのAPI提供

🤖 Generated with Claude Code