### PR TITLE
feat: 定期実行ジョブの実装

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -54,9 +54,17 @@ sea-orm = { version = "1.1", features = ["sqlx-sqlite", "sqlx-postgres", "runtim
 sea-orm-migration = "1.1"
 clap = { version = "4.5.41", features = ["derive"] }
 
+# スケジューラー
+tokio-cron-scheduler = "0.11"
+uuid = { version = "1.11", features = ["v4"] }
+
 [[bin]]
 name = "scrape"
 path = "src/bin/scrape.rs"
+
+[[bin]]
+name = "scheduler"
+path = "src/bin/scheduler.rs"
 
 [dev-dependencies]
 # テスト用

--- a/backend/src/bin/scheduler.rs
+++ b/backend/src/bin/scheduler.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
 
     // マイグレーション実行
     sqlx::migrate!("./migrations").run(&pool).await?;
-    
+
     info!("Database initialized");
 
     // 起動時に即座に実行するオプション
@@ -54,13 +54,13 @@ async fn main() -> Result<()> {
     // スケジューラー作成・開始
     let mut scheduler = create_scheduler(pool).await?;
     scheduler.start().await?;
-    
+
     info!("Scheduler started. Press Ctrl+C to stop.");
     info!("Jobs will run every 5 minutes at :00, :05, :10, :15, etc.");
 
     // Ctrl+Cを待つ
     signal::ctrl_c().await?;
-    
+
     info!("Shutting down scheduler...");
     scheduler.shutdown().await?;
     info!("Scheduler stopped successfully");

--- a/backend/src/bin/scheduler.rs
+++ b/backend/src/bin/scheduler.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use clap::Parser;
+use nba_trade_scraper::scheduler::{create_scheduler, run_scraping_job};
+use sqlx::SqlitePool;
+use std::path::PathBuf;
+use tokio::signal;
+use tracing::{error, info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[derive(Parser)]
+#[command(name = "scheduler")]
+#[command(about = "NBAニュースの定期スクレイピングスケジューラー")]
+struct Cli {
+    /// データベースファイルのパス
+    #[arg(short, long, default_value = "nba_trades.db")]
+    database: PathBuf,
+
+    /// 起動時に即座にスクレイピングを実行
+    #[arg(short, long)]
+    immediate: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // ログの初期化
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let cli = Cli::parse();
+
+    info!("Starting NBA Trade Scraper Scheduler...");
+
+    // データベース接続
+    let database_url = format!("sqlite:{}", cli.database.display());
+    info!("Connecting to database: {}", database_url);
+    let pool = SqlitePool::connect(&database_url).await?;
+
+    // マイグレーション実行
+    sqlx::migrate!("./migrations").run(&pool).await?;
+    
+    info!("Database initialized");
+
+    // 起動時に即座に実行するオプション
+    if cli.immediate {
+        info!("Running immediate scraping job...");
+        match run_scraping_job(pool.clone()).await {
+            Ok(_) => info!("Initial scraping completed successfully"),
+            Err(e) => error!("Initial scraping failed: {}", e),
+        }
+    }
+
+    // スケジューラー作成・開始
+    let mut scheduler = create_scheduler(pool).await?;
+    scheduler.start().await?;
+    
+    info!("Scheduler started. Press Ctrl+C to stop.");
+    info!("Jobs will run every 5 minutes at :00, :05, :10, :15, etc.");
+
+    // Ctrl+Cを待つ
+    signal::ctrl_c().await?;
+    
+    info!("Shutting down scheduler...");
+    scheduler.shutdown().await?;
+    info!("Scheduler stopped successfully");
+
+    Ok(())
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -44,5 +44,8 @@ pub mod graphql;
 /// RSSスクレイピング機能
 pub mod scraper;
 
+/// スケジューラー機能
+pub mod scheduler;
+
 /// ユーティリティ関数
 pub mod utils;

--- a/backend/src/scheduler/mod.rs
+++ b/backend/src/scheduler/mod.rs
@@ -1,0 +1,152 @@
+//! スケジューラー関連の機能
+//!
+//! 定期的なスクレイピングジョブの実行を管理します。
+
+use anyhow::Result;
+use sqlx::SqlitePool;
+use tokio_cron_scheduler::{Job, JobScheduler};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::scraper::{NewsPersistence, RssParser};
+
+/// スクレイピングジョブを実行する
+pub async fn run_scraping_job(pool: SqlitePool) -> Result<()> {
+    info!("Starting scraping job");
+    
+    // RSSフィードからニュースを取得
+    let parser = RssParser::new();
+    let news_items = parser.fetch_all_feeds().await?;
+    
+    info!("Fetched {} news items", news_items.len());
+    
+    // データベースに保存
+    let persistence = NewsPersistence::new(pool);
+    let result = persistence.save_news_items(news_items).await?;
+    
+    info!(
+        "Scraping job completed: {} saved, {} skipped, {} errors",
+        result.saved_count, result.skipped_count, result.errors.len()
+    );
+    
+    if !result.errors.is_empty() {
+        for (id, error) in &result.errors {
+            error!("Error saving item {}: {}", id, error);
+        }
+    }
+    
+    Ok(())
+}
+
+/// スケジューラーを作成し、設定する
+pub async fn create_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
+    let scheduler = JobScheduler::new().await?;
+    
+    // 5分ごとのスクレイピングジョブを作成
+    // cron式: "秒 分 時 日 月 曜日"
+    // "0 */5 * * * *" = 毎時0分、5分、10分、15分...に実行
+    let job = Job::new_async("0 */5 * * * *", move |_uuid, _lock| {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let job_id = Uuid::new_v4();
+            info!("Starting scheduled scraping job: {}", job_id);
+            
+            match run_scraping_job(pool).await {
+                Ok(_) => {
+                    info!("Scheduled job {} completed successfully", job_id);
+                }
+                Err(e) => {
+                    error!("Scheduled job {} failed: {}", job_id, e);
+                }
+            }
+        })
+    })?;
+    
+    scheduler.add(job).await?;
+    
+    info!("Scheduler initialized with 5-minute scraping interval");
+    
+    Ok(scheduler)
+}
+
+/// 即座にスクレイピングジョブを実行するスケジューラーを作成（テスト用）
+pub async fn create_immediate_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
+    let scheduler = JobScheduler::new().await?;
+    
+    // 30秒後に1回だけ実行するジョブ（デモ用）
+    let job = Job::new_one_shot_async(
+        std::time::Duration::from_secs(30),
+        move |_uuid, _lock| {
+            let pool = pool.clone();
+            Box::pin(async move {
+                let job_id = Uuid::new_v4();
+                info!("Starting one-shot scraping job: {}", job_id);
+                
+                match run_scraping_job(pool).await {
+                    Ok(_) => {
+                        info!("One-shot job {} completed successfully", job_id);
+                    }
+                    Err(e) => {
+                        error!("One-shot job {} failed: {}", job_id, e);
+                    }
+                }
+            })
+        },
+    )?;
+    
+    scheduler.add(job).await?;
+    
+    info!("Scheduler initialized with one-shot job (30 seconds)");
+    
+    Ok(scheduler)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[tokio::test]
+    async fn test_create_scheduler() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        
+        // マイグレーションを実行
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        
+        let mut scheduler = create_scheduler(pool).await.unwrap();
+        
+        // スケジューラーが作成されることを確認
+        assert!(scheduler.next_tick_for_job(Uuid::nil()).await.is_ok());
+    }
+    
+    #[tokio::test]
+    async fn test_create_immediate_scheduler() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        
+        // マイグレーションを実行
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        
+        let mut scheduler = create_immediate_scheduler(pool).await.unwrap();
+        
+        // スケジューラーが作成されることを確認
+        assert!(scheduler.next_tick_for_job(Uuid::nil()).await.is_ok());
+    }
+    
+    #[tokio::test]
+    async fn test_run_scraping_job() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        
+        // マイグレーションを実行
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        
+        // スクレイピングジョブが正常に実行されることを確認
+        // 実際のRSSフィード取得はモックしないので、エラーにならないことだけ確認
+        let result = run_scraping_job(pool).await;
+        
+        // ネットワークエラーの可能性があるので、結果は問わない
+        // ただし、パニックしないことを確認
+        match result {
+            Ok(_) => println!("Scraping job succeeded"),
+            Err(e) => println!("Scraping job failed (expected in test): {}", e),
+        }
+    }
+}

--- a/backend/src/scheduler/mod.rs
+++ b/backend/src/scheduler/mod.rs
@@ -13,35 +13,37 @@ use crate::scraper::{NewsPersistence, RssParser};
 /// スクレイピングジョブを実行する
 pub async fn run_scraping_job(pool: SqlitePool) -> Result<()> {
     info!("Starting scraping job");
-    
+
     // RSSフィードからニュースを取得
     let parser = RssParser::new();
     let news_items = parser.fetch_all_feeds().await?;
-    
+
     info!("Fetched {} news items", news_items.len());
-    
+
     // データベースに保存
     let persistence = NewsPersistence::new(pool);
     let result = persistence.save_news_items(news_items).await?;
-    
+
     info!(
         "Scraping job completed: {} saved, {} skipped, {} errors",
-        result.saved_count, result.skipped_count, result.errors.len()
+        result.saved_count,
+        result.skipped_count,
+        result.errors.len()
     );
-    
+
     if !result.errors.is_empty() {
         for (id, error) in &result.errors {
             error!("Error saving item {}: {}", id, error);
         }
     }
-    
+
     Ok(())
 }
 
 /// スケジューラーを作成し、設定する
 pub async fn create_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
     let scheduler = JobScheduler::new().await?;
-    
+
     // 5分ごとのスクレイピングジョブを作成
     // cron式: "秒 分 時 日 月 曜日"
     // "0 */5 * * * *" = 毎時0分、5分、10分、15分...に実行
@@ -50,7 +52,7 @@ pub async fn create_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
         Box::pin(async move {
             let job_id = Uuid::new_v4();
             info!("Starting scheduled scraping job: {}", job_id);
-            
+
             match run_scraping_job(pool).await {
                 Ok(_) => {
                     info!("Scheduled job {} completed successfully", job_id);
@@ -61,87 +63,84 @@ pub async fn create_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
             }
         })
     })?;
-    
+
     scheduler.add(job).await?;
-    
+
     info!("Scheduler initialized with 5-minute scraping interval");
-    
+
     Ok(scheduler)
 }
 
 /// 即座にスクレイピングジョブを実行するスケジューラーを作成（テスト用）
 pub async fn create_immediate_scheduler(pool: SqlitePool) -> Result<JobScheduler> {
     let scheduler = JobScheduler::new().await?;
-    
+
     // 30秒後に1回だけ実行するジョブ（デモ用）
-    let job = Job::new_one_shot_async(
-        std::time::Duration::from_secs(30),
-        move |_uuid, _lock| {
-            let pool = pool.clone();
-            Box::pin(async move {
-                let job_id = Uuid::new_v4();
-                info!("Starting one-shot scraping job: {}", job_id);
-                
-                match run_scraping_job(pool).await {
-                    Ok(_) => {
-                        info!("One-shot job {} completed successfully", job_id);
-                    }
-                    Err(e) => {
-                        error!("One-shot job {} failed: {}", job_id, e);
-                    }
+    let job = Job::new_one_shot_async(std::time::Duration::from_secs(30), move |_uuid, _lock| {
+        let pool = pool.clone();
+        Box::pin(async move {
+            let job_id = Uuid::new_v4();
+            info!("Starting one-shot scraping job: {}", job_id);
+
+            match run_scraping_job(pool).await {
+                Ok(_) => {
+                    info!("One-shot job {} completed successfully", job_id);
                 }
-            })
-        },
-    )?;
-    
+                Err(e) => {
+                    error!("One-shot job {} failed: {}", job_id, e);
+                }
+            }
+        })
+    })?;
+
     scheduler.add(job).await?;
-    
+
     info!("Scheduler initialized with one-shot job (30 seconds)");
-    
+
     Ok(scheduler)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[tokio::test]
     async fn test_create_scheduler() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        
+
         // マイグレーションを実行
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-        
+
         let mut scheduler = create_scheduler(pool).await.unwrap();
-        
+
         // スケジューラーが作成されることを確認
         assert!(scheduler.next_tick_for_job(Uuid::nil()).await.is_ok());
     }
-    
+
     #[tokio::test]
     async fn test_create_immediate_scheduler() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        
+
         // マイグレーションを実行
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-        
+
         let mut scheduler = create_immediate_scheduler(pool).await.unwrap();
-        
+
         // スケジューラーが作成されることを確認
         assert!(scheduler.next_tick_for_job(Uuid::nil()).await.is_ok());
     }
-    
+
     #[tokio::test]
     async fn test_run_scraping_job() {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        
+
         // マイグレーションを実行
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-        
+
         // スクレイピングジョブが正常に実行されることを確認
         // 実際のRSSフィード取得はモックしないので、エラーにならないことだけ確認
         let result = run_scraping_job(pool).await;
-        
+
         // ネットワークエラーの可能性があるので、結果は問わない
         // ただし、パニックしないことを確認
         match result {


### PR DESCRIPTION
## 概要
RSSフィードを定期的に自動スクレイピングする機能を実装しました。

## 実装内容
- tokio-cron-schedulerを使用した5分間隔のスクレイピング
- `scheduler`バイナリの追加
- CLIオプション：`--immediate`で起動時即座に実行
- スケジューラーモジュールの実装とテスト

## 使用方法
```bash
# 通常起動（5分間隔でスクレイピング）
cargo run --bin scheduler

# 起動時に即座に実行してから定期実行
cargo run --bin scheduler -- --immediate

# データベースファイルを指定
cargo run --bin scheduler -- --database custom.db
```

## テスト
```bash
cargo test scheduler
```

🤖 Generated with [Claude Code](https://claude.ai/code)