### PR TITLE
feat: バックエンドCORS設定とポート変更

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,6 +43,7 @@ dotenv = "0.15"
 
 # HTTPサーバー（GraphQL用に後で使用）
 axum = "0.8"
+tower-http = { version = "0.5", features = ["cors"] }
 
 # GraphQL（後で使用）
 async-graphql = { version = "7.0", features = ["apollo_tracing", "log"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,7 @@ use axum::{response::Html, routing::get, serve, Router};
 use nba_trade_scraper::graphql::{create_schema, Query};
 use sqlx::SqlitePool;
 use tokio::net::TcpListener;
+use tower_http::cors::{Any, CorsLayer};
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
@@ -40,13 +41,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let schema = create_schema(pool);
 
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
     let app = Router::new()
         .route("/", get(graphiql).post(graphql_handler))
+        .layer(cors)
         .layer(axum::extract::Extension(schema));
 
-    info!("GraphQL playground available at http://localhost:3000");
+    info!("GraphQL playground available at http://localhost:8000");
 
-    let listener = TcpListener::bind("0.0.0.0:3000").await?;
+    let listener = TcpListener::bind("0.0.0.0:8000").await?;
     serve(listener, app).await?;
 
     Ok(())


### PR DESCRIPTION
## 概要
フロントエンドとの通信を可能にするため、バックエンドにCORS設定を追加し、ポートを変更します。

## 変更内容
- tower-httpクレートを追加してCORS対応
- GraphQLエンドポイントのポートを3000から8000に変更
- すべてのオリジン、メソッド、ヘッダーを許可（開発環境用）

## テスト方法
```bash
cargo run --bin nba-trade-scraper
```
http://localhost:8000 でGraphQL Playgroundが利用可能

## 関連
この変更は、後続のKotlinフロントエンド実装PRで必要となります。

🤖 Generated with [Claude Code](https://claude.ai/code)