### PR TITLE
feat: Airflow連携用のGraphQL Mutation実装

### DIFF
--- a/backend/src/graphql.rs
+++ b/backend/src/graphql.rs
@@ -194,7 +194,7 @@ impl Mutation {
             errors: save_result
                 .errors
                 .into_iter()
-                .map(|(id, msg)| format!("{}: {}", id, msg))
+                .map(|(id, msg)| format!("{id}: {msg}"))
                 .collect(),
         })
     }

--- a/backend/src/graphql.rs
+++ b/backend/src/graphql.rs
@@ -8,11 +8,12 @@
 //! - `tradeNewsByCategory`: カテゴリー別にニュースを取得
 //! - `tradeNewsBySource`: ソース別にニュースを取得
 
-use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+use async_graphql::{Context, EmptySubscription, Object, Schema, SimpleObject};
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
+use tracing::info;
 
-use crate::scraper::{NewsItem, NewsPersistence};
+use crate::scraper::{NewsItem, NewsPersistence, RssParser};
 
 /// GraphQLで返されるトレードニュースの構造体
 #[derive(SimpleObject)]
@@ -158,20 +159,72 @@ impl Query {
     }
 }
 
+/// GraphQLミューテーションのルート
+pub struct Mutation;
+
+#[Object]
+impl Mutation {
+    /// RSSフィードをスクレイピングしてデータベースに保存
+    async fn scrape_rss(&self, ctx: &Context<'_>) -> async_graphql::Result<ScrapeResult> {
+        let pool = ctx.data::<SqlitePool>()?;
+        let persistence = NewsPersistence::new(pool.clone());
+        
+        info!("Starting RSS scraping via GraphQL mutation...");
+        
+        // RSSフィードをパース
+        let parser = RssParser::new();
+        let news_items = parser.fetch_all_feeds().await?;
+        
+        info!("Fetched {} items from RSS feeds", news_items.len());
+        
+        // データベースに保存
+        let save_result = persistence.save_news_items(news_items).await?;
+        
+        info!(
+            "Scraping completed: {} saved, {} skipped, {} errors",
+            save_result.saved_count,
+            save_result.skipped_count,
+            save_result.errors.len()
+        );
+        
+        Ok(ScrapeResult {
+            saved_count: save_result.saved_count as i32,
+            skipped_count: save_result.skipped_count as i32,
+            error_count: save_result.errors.len() as i32,
+            errors: save_result.errors.into_iter()
+                .map(|(id, msg)| format!("{}: {}", id, msg))
+                .collect(),
+        })
+    }
+}
+
+/// スクレイピング結果
+#[derive(SimpleObject)]
+pub struct ScrapeResult {
+    /// 新規保存されたアイテム数
+    pub saved_count: i32,
+    /// 重複のためスキップされたアイテム数
+    pub skipped_count: i32,
+    /// エラー数
+    pub error_count: i32,
+    /// エラーメッセージのリスト
+    pub errors: Vec<String>,
+}
+
 pub type QueryRoot = Query;
 
-pub fn create_schema(pool: SqlitePool) -> Schema<Query, EmptyMutation, EmptySubscription> {
-    Schema::build(Query, EmptyMutation, EmptySubscription)
+pub fn create_schema(pool: SqlitePool) -> Schema<Query, Mutation, EmptySubscription> {
+    Schema::build(Query, Mutation, EmptySubscription)
         .data(pool)
         .finish()
 }
 
-pub fn graphql_routes(schema: Schema<Query, EmptyMutation, EmptySubscription>) -> axum::Router {
+pub fn graphql_routes(schema: Schema<Query, Mutation, EmptySubscription>) -> axum::Router {
     use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
     use axum::{extract::State, response::Html, routing::get, Router};
 
     async fn graphql_handler(
-        State(schema): State<Schema<Query, EmptyMutation, EmptySubscription>>,
+        State(schema): State<Schema<Query, Mutation, EmptySubscription>>,
         req: GraphQLRequest,
     ) -> GraphQLResponse {
         schema.execute(req.into_inner()).await.into()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
 use async_graphql::{http::GraphiQLSource, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{response::Html, routing::get, serve, Router};
-use nba_trade_scraper::graphql::{create_schema, Query, Mutation};
+use nba_trade_scraper::graphql::{create_schema, Mutation, Query};
 use sqlx::SqlitePool;
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
-use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
+use async_graphql::{http::GraphiQLSource, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{response::Html, routing::get, serve, Router};
-use nba_trade_scraper::graphql::{create_schema, Query};
+use nba_trade_scraper::graphql::{create_schema, Query, Mutation};
 use sqlx::SqlitePool;
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
@@ -9,7 +9,7 @@ use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
 async fn graphql_handler(
-    schema: axum::extract::Extension<Schema<Query, EmptyMutation, EmptySubscription>>,
+    schema: axum::extract::Extension<Schema<Query, Mutation, EmptySubscription>>,
     req: GraphQLRequest,
 ) -> GraphQLResponse {
     schema.execute(req.into_inner()).await.into()


### PR DESCRIPTION
## Summary
Amazon MWAA (Airflow) から呼び出すためのGraphQL Mutationを実装しました。

## Changes
- GraphQL Mutation `scrapeRss` を追加
- Airflow DAGから5分ごとに呼び出される想定
- 手動実行も可能（GraphQL Playground経由）

## Technical Details
- スケジューリングはAirflow側で管理
- バックエンドはステートレスなAPIとして動作
- 既存の `RssParser` と `NewsPersistence` を活用

## Airflow DAGとの連携
```python
# airflow/dags/nba_rss_scraper.py から抜粋
mutation = """
mutation ScrapeRss {
    scrapeRss {
        savedCount
        skippedCount
        errorCount
        errors
    }
}
"""
```

## Test plan
- [x] `cargo test` で全テストが成功
- [x] `cargo build` でビルドエラーなし
- [ ] GraphQL Playground で `scrapeRss` mutation を実行して動作確認
- [ ] Airflow DAGからの呼び出しテスト（MWAA環境構築後）

## 依存関係
このPRは #22（データ永続化）がマージされた後にマージしてください。

🤖 Generated with [Claude Code](https://claude.ai/code)