### PR TITLE
feat: HTMLタグ除去機能の実装

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,6 +44,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # HTMLパーサー（将来的に使用）
 scraper = "0.20"
 
+# 正規表現
+regex = "1.11"
+
 # 環境変数
 dotenv = "0.15"
 

--- a/backend/src/graphql.rs
+++ b/backend/src/graphql.rs
@@ -14,6 +14,7 @@ use sqlx::postgres::PgPool;
 use tracing::info;
 
 use crate::scraper::{NewsItem, NewsPersistence, RssParser};
+use crate::utils::string_utils::strip_html_tags;
 
 /// GraphQLで返されるトレードニュースの構造体
 #[derive(SimpleObject)]
@@ -38,8 +39,8 @@ impl From<NewsItem> for TradeNews {
     fn from(item: NewsItem) -> Self {
         TradeNews {
             id: item.id,
-            title: item.title,
-            description: item.description,
+            title: strip_html_tags(&item.title),
+            description: item.description.map(|desc| strip_html_tags(&desc)),
             link: item.link,
             source: item.source.to_string(),
             published_at: item.published_at,

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -1,5 +1,7 @@
 /// ユーティリティ関数モジュール
 pub mod string_utils {
+    use regex::Regex;
+
     /// 文字列を大文字に変換
     pub fn to_uppercase(s: &str) -> String {
         s.to_uppercase()
@@ -13,6 +15,29 @@ pub mod string_utils {
     /// 文字列の前後の空白を除去
     pub fn trim(s: &str) -> String {
         s.trim().to_string()
+    }
+
+    /// HTMLタグを除去してプレーンテキストに変換
+    pub fn strip_html_tags(html: &str) -> String {
+        // HTMLタグを除去する正規表現
+        let tag_regex = Regex::new(r"<[^>]+>").unwrap();
+        let mut text = tag_regex.replace_all(html, " ").to_string();
+
+        // HTMLエンティティをデコード
+        text = text
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&nbsp;", " ");
+
+        // 連続する空白を1つに
+        let whitespace_regex = Regex::new(r"\s+").unwrap();
+        text = whitespace_regex.replace_all(&text, " ").to_string();
+
+        // 前後の空白を除去
+        text.trim().to_string()
     }
 }
 
@@ -39,5 +64,50 @@ mod tests {
         assert_eq!(trim("no_space"), "no_space");
         assert_eq!(trim(""), "");
         assert_eq!(trim("   "), "");
+    }
+
+    #[test]
+    fn test_strip_html_tags() {
+        // 基本的なHTMLタグの除去
+        assert_eq!(strip_html_tags("<p>Hello World</p>"), "Hello World");
+        assert_eq!(
+            strip_html_tags("<p>Hello <strong>World</strong></p>"),
+            "Hello World"
+        );
+
+        // 複数のタグと属性
+        assert_eq!(
+            strip_html_tags("<div class=\"test\"><p>Hello</p><br/><span>World</span></div>"),
+            "Hello World"
+        );
+
+        // HTMLエンティティ
+        assert_eq!(
+            strip_html_tags("&lt;p&gt;Hello &amp; World&lt;/p&gt;"),
+            "<p>Hello & World</p>"
+        );
+
+        // 実際のRSSフィードからのデータ例
+        assert_eq!(
+            strip_html_tags("<p>The Miami Heat did not want to include draft capital.</p>\r<p>More content here.</p>"),
+            "The Miami Heat did not want to include draft capital. More content here."
+        );
+
+        // リンクを含むケース
+        assert_eq!(
+            strip_html_tags(
+                "<p>Check out <a href=\"https://example.com\">this link</a> for more info.</p>"
+            ),
+            "Check out this link for more info."
+        );
+
+        // 空のタグ
+        assert_eq!(strip_html_tags("<p></p><div></div>"), "");
+
+        // タグがない場合
+        assert_eq!(
+            strip_html_tags("Plain text without tags"),
+            "Plain text without tags"
+        );
     }
 }

--- a/docs/daily/2025-07-30.md
+++ b/docs/daily/2025-07-30.md
@@ -20,18 +20,23 @@
   - Kotlin/JS + Compose for Webで構築
   - GraphQLクライアントでバックエンドに接続
 
-### 4. マイグレーションファイルの修正
-```sql
--- teamsテーブルの修正
-ALTER TABLE teams ADD COLUMN IF NOT EXISTS abbreviation TEXT;
--- データ挿入時にabbreviationを含めるよう修正
-```
+### 4. CI/CDの修正
+- GitHub Actions CIのエラーを解決
+  - teamsテーブルの初期定義にabbreviationカラムを追加
+  - 不要なマイグレーションファイルを削除
+  - PR#48で全てのCIチェックが成功
+
+### 5. PR#48のマージ
+- フロントエンド・バックエンド統合の初期実装が完了
+- mainブランチにマージ済み
 
 ## 成果
 - ✅ バックエンドAPIが正常に起動
 - ✅ GraphQLクエリでデータ取得確認
 - ✅ フロントエンド開発サーバーが起動
 - ✅ 初期ニュースデータ40件を投入
+- ✅ PR#48: フロントエンド・バックエンド統合（マージ済み）
+- ✅ 全CIチェックが成功
 
 ## 技術的な詳細
 - CORS設定: `.allow_origin(Any)`で全オリジンを許可
@@ -43,8 +48,10 @@ ALTER TABLE teams ADD COLUMN IF NOT EXISTS abbreviation TEXT;
 - Dockerコンテナとローカル開発環境のポート競合
 - マイグレーションの順序とテーブル制約の整合性が重要
 - `nohup`を使用したバックグラウンドプロセスの管理
+- Gitの`--amend --no-edit`で既存コミットに変更を追加できる
 
 ## 次回の作業予定
-- フロントエンドでのニュース表示の動作確認
-- エラーハンドリングの改善
-- 本番環境向けの設定準備
+- HTMLタグ除去処理の実装（`<p>`タグなどの削除）
+- UIレイアウトの改善（カード型3列表示）
+- 日本語翻訳機能の実装
+- 記事サマリー生成機能の追加


### PR DESCRIPTION
## Summary
- RSSフィードから取得したニュースのHTMLタグを除去する機能を実装
- GraphQL APIレスポンスでクリーンなテキストを返すように改善
- HTMLエンティティのデコードにも対応

## Changes
- `backend/src/utils/mod.rs`: `strip_html_tags`関数を追加
- `backend/src/graphql.rs`: TradeNewsへの変換時にHTMLタグを除去
- `backend/Cargo.toml`: regex依存関係を追加

## Test Plan
- [x] HTMLタグ除去のユニットテストを実装
- [x] GraphQL APIでHTMLタグが正しく除去されることを確認
- [x] 全テストがパス
- [x] pre-commitチェックがパス

## Example
変換前: `<p>The Miami Heat did not want to include draft capital.</p>`
変換後: `The Miami Heat did not want to include draft capital.`

🤖 Generated with [Claude Code](https://claude.ai/code)